### PR TITLE
test-cases: adjust to RelativePathSource

### DIFF
--- a/test-cases/invalid/RMLSTARTC009/mapping.ttl
+++ b/test-cases/invalid/RMLSTARTC009/mapping.ttl
@@ -6,7 +6,9 @@
 
 :firstTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -21,7 +23,9 @@
 
 :secondTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/invalid/RMLSTARTC010/mapping.ttl
+++ b/test-cases/invalid/RMLSTARTC010/mapping.ttl
@@ -6,7 +6,9 @@
 
 :firstTM a rml:AssertedTriplesMap, rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -19,7 +21,9 @@
 
 :secondTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC001a/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC001a/mapping.ttl
@@ -6,7 +6,9 @@
 
 :firstTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC001b/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC001b/mapping.ttl
@@ -6,7 +6,9 @@
 
 :firstTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC002a/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC002a/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -23,7 +25,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC002b/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC002b/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -23,7 +25,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC003a/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC003a/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -37,7 +41,9 @@
 
 :thirdTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC003b/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC003b/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -37,7 +41,9 @@
 
 :thirdTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC004a/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC004a/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -37,7 +41,9 @@
 
 :thirdTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC004b/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC004b/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -37,7 +41,9 @@
 
 :thirdTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC005a/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC005a/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC005b/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC005b/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC006a/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC006a/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:NonAssertedTriplesMap ; # This refers to the y statement in the rdf-star
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;  # This refers to the x statement in the rdf-star
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC006b/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC006b/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:NonAssertedTriplesMap ; # This refers to the y statement in the rdf-star
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ; # This refers to the x statement in the rdf-star
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC007a/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC007a/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -37,7 +41,9 @@
 
 :thirdTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC007b/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC007b/mapping.ttl
@@ -7,7 +7,9 @@
 
 :firstTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :secondTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -41,7 +45,9 @@
 
 :thirdTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC008a/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC008a/mapping.ttl
@@ -7,7 +7,9 @@
 
 :elementaryTM1 a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :firstJoinTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -37,7 +41,9 @@
 
 :elementaryTM2 a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -52,7 +58,9 @@
 
 :centralJoinTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -67,7 +75,9 @@
 
 :elementaryTM3 a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -82,7 +92,9 @@
 
 :secondJoinTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -97,7 +109,9 @@
 
 :elementaryTM4 a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [

--- a/test-cases/valid/RMLSTARTC008b/mapping.ttl
+++ b/test-cases/valid/RMLSTARTC008b/mapping.ttl
@@ -7,7 +7,9 @@
 
 :elementaryTM1 a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -22,7 +24,9 @@
 
 :firstJoinTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -37,7 +41,9 @@
 
 :elementaryTM2 a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data1.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data1.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -52,7 +58,9 @@
 
 :centralJoinTM a rml:AssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -71,7 +79,9 @@
 
 :elementaryTM3 a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -86,7 +96,9 @@
 
 :secondJoinTM a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [
@@ -101,7 +113,9 @@
 
 :elementaryTM4 a rml:NonAssertedTriplesMap ;
     rml:logicalSource [
-        rml:source "data2.csv";
+        rml:source [ a rml:Source, rml:RelativePathSource;
+            rml:path "data2.csv";
+        ];
         rml:referenceFormulation rml:CSV
     ];
     rml:subjectMap [


### PR DESCRIPTION
Test-cases were still using `rml:source "data.csv"` which is not allowed anymore. 

CC: @anaigmo @arenas-guerrero-julian 